### PR TITLE
블로그 포스트에 Disqus 댓글 기능 추가

### DIFF
--- a/blog-state.md
+++ b/blog-state.md
@@ -33,14 +33,16 @@ donbunnypark.github.io/
     "title": "블로그를 시작합니다",
     "date": "2025-04-15",
     "path": "posts/first-post.html",
-    "description": "Don Bunny Park's Notes 블로그를 시작합니다. 앞으로 AI 도구들을 활용하면서 경험한 것들과 배운 것들을 기록할 예정입니다."
+    "description": "Don Bunny Park's Notes 블로그를 시작합니다. 앞으로 AI 도구들을 활용하면서 경험한 것들과 배운 것들을 기록할 예정입니다.",
+    "comments": true
   },
   {
     "id": "claude-blogging",
     "title": "Claude를 이용하여 블로그하기",
     "date": "2025-04-15",
     "path": "posts/claude-blogging.html",
-    "description": "Claude와 MCP를 활용하여 드디어 GitHub Pages 블로그를 만들게 된 경험과 AI 도구 활용에 대한 생각을 공유합니다."
+    "description": "Claude와 MCP를 활용하여 드디어 GitHub Pages 블로그를 만들게 된 경험과 AI 도구 활용에 대한 생각을 공유합니다.",
+    "comments": true
   }
 ]
 ```
@@ -70,7 +72,8 @@ Nodes = [
   { id: "readme", label: "README", type: "document" },
   { id: "posts_dir", label: "포스트 디렉토리", type: "directory" },
   { id: "post1", label: "블로그를 시작합니다", type: "post" },
-  { id: "post2", label: "Claude를 이용하여 블로그하기", type: "post" }
+  { id: "post2", label: "Claude를 이용하여 블로그하기", type: "post" },
+  { id: "disqus", label: "Disqus 댓글 시스템", type: "external_service" }
 ]
 
 // 엣지 (관계)
@@ -85,7 +88,9 @@ Edges = [
   { from: "post1", to: "styles", relationship: "IMPORTS" },
   { from: "post2", to: "styles", relationship: "IMPORTS" },
   { from: "index", to: "post1", relationship: "LINKS_TO" },
-  { from: "index", to: "post2", relationship: "LINKS_TO" }
+  { from: "index", to: "post2", relationship: "LINKS_TO" },
+  { from: "post1", to: "disqus", relationship: "INTEGRATES" },
+  { from: "post2", to: "disqus", relationship: "INTEGRATES" }
 ]
 ```
 
@@ -109,10 +114,21 @@ Edges = [
   "postTemplate": {
     "header": "동일",
     "content": "포스트별 내용",
+    "comments": "Disqus 댓글 시스템",
     "navigation": "홈으로 돌아가기 링크"
   },
   "footer": {
     "copyright": "© 2025 Don Bunny Park. All rights reserved."
+  },
+  "externalServices": {
+    "disqus": {
+      "shortname": "https-moojittokki-github-io-donbunnypark-github-io",
+      "configPerPost": {
+        "url": "[포스트의 전체 웹 주소]",
+        "identifier": "[포스트 경로 또는 ID]",
+        "title": "[포스트 제목]"
+      }
+    }
   }
 }
 ```
@@ -121,9 +137,14 @@ Edges = [
 - 생성일: 2025-04-15
 - 마지막 업데이트: 2025-04-19
 - 총 포스트 수: 2
+- 모든 포스트에 Disqus 댓글 기능 추가 (2025-04-19)
 
 ## 앞으로 작업 시 참고사항
 - 새 포스트 추가할 때 날짜 형식: "YYYY년 MM월 DD일"
 - 모든 .html 파일에 스타일시트 링크 포함 필요
 - 폰트 클래스 적용: dongle-light, dongle-regular, dongle-bold
 - 모든 페이지에 헤더와 푸터 일관되게 유지
+- 새 포스트 생성 시 Disqus 댓글 코드도 함께 추가 필요
+  - URL: 'https://moojittokki.github.io/donbunnypark.github.io/[포스트 경로]'
+  - identifier: '[포스트 경로 또는 ID]'
+  - title: '[포스트 제목]'

--- a/posts/claude-blogging.html
+++ b/posts/claude-blogging.html
@@ -100,6 +100,31 @@ AI도 잘 모르고, IT도 서툽니다.
                 <p>다만 앞으로 내가 원하는 것을 더욱 구체적으로 설명할 필요가 있다는 생각도 들었다. 나는 단지 블로그를 개설만 하려 했지만, Claude는 첫 게시물까지 만들어 올려버렸다. 내가 원하지 않은 결과물과 그 내용을 보며, Claude가 과도한 작업을 했다고 탓하기보다는 프롬프팅 능력이 부족한 나의 책임이라 생각해본다.</p>
             </div>
             
+            <!-- 댓글 섹션 추가 -->
+            <div id="disqus_thread"></div>
+            <script>
+                /**
+                * RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+                * LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables
+                */
+                var disqus_config = function () {
+                    // 이 포스트의 URL, 식별자, 제목을 설정합니다.
+                    this.page.url = 'https://moojittokki.github.io/donbunnypark.github.io/posts/claude-blogging.html';
+                    this.page.identifier = 'posts/claude-blogging.html';
+                    this.page.title = 'Claude를 이용하여 블로그하기';
+                };
+                (function() { // DON'T EDIT BELOW THIS LINE
+                    var d = document, s = d.createElement('script');
+                    s.src = 'https://' + 'https-moojittokki-github-io-donbunnypark-github-io' + '.disqus.com/embed.js'; // 사용자님의 Shortname이 여기에 들어갑니다.
+                    s.setAttribute('data-timestamp', +new Date());
+                    (d.head || d.body).appendChild(s);
+                })();
+            </script>
+            <noscript>
+                댓글을 보려면 JavaScript를 활성화하세요. <a href="https://disqus.com/?ref_noscript">Disqus 구동 댓글 로드</a>
+            </noscript>
+            <!-- 댓글 섹션 끝 -->
+            
             <div class="post-navigation">
                 <a href="../index.html" class="back-link dongle-regular">← 홈으로 돌아가기</a>
             </div>

--- a/posts/first-post.html
+++ b/posts/first-post.html
@@ -36,6 +36,31 @@
                 <p>블로그를 운영하면서 배우는 것들도 함께 기록할 예정이니 많은 관심 부탁드립니다!</p>
             </div>
             
+            <!-- 댓글 섹션 추가 -->
+            <div id="disqus_thread"></div>
+            <script>
+                /**
+                * RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+                * LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables
+                */
+                var disqus_config = function () {
+                    // 이 포스트의 URL, 식별자, 제목을 설정합니다.
+                    this.page.url = 'https://moojittokki.github.io/donbunnypark.github.io/posts/first-post.html';
+                    this.page.identifier = 'posts/first-post.html';
+                    this.page.title = '블로그를 시작합니다';
+                };
+                (function() { // DON'T EDIT BELOW THIS LINE
+                    var d = document, s = d.createElement('script');
+                    s.src = 'https://' + 'https-moojittokki-github-io-donbunnypark-github-io' + '.disqus.com/embed.js'; // 사용자님의 Shortname이 여기에 들어갑니다.
+                    s.setAttribute('data-timestamp', +new Date());
+                    (d.head || d.body).appendChild(s);
+                })();
+            </script>
+            <noscript>
+                댓글을 보려면 JavaScript를 활성화하세요. <a href="https://disqus.com/?ref_noscript">Disqus 구동 댓글 로드</a>
+            </noscript>
+            <!-- 댓글 섹션 끝 -->
+            
             <div class="post-navigation">
                 <a href="../index.html" class="back-link dongle-regular">← 홈으로 돌아가기</a>
             </div>


### PR DESCRIPTION
## 변경사항
- 모든 블로그 포스트 페이지에 Disqus 댓글 시스템 추가
  - 첫 번째 포스트 "블로그를 시작합니다"에 댓글 기능 추가
  - 두 번째 포스트 "Claude를 이용하여 블로그하기"에 댓글 기능 추가
- 각 포스트별로 다음 정보를 설정
  - URL: 페이지의 전체 주소
  - identifier: 포스트 경로
  - title: 포스트 제목
- blog-state.md 문서 업데이트하여 Disqus 통합 내용 반영

## 테스트 방법
1. 각 포스트 페이지에 접속
2. 댓글 섹션이 포스트 내용 아래에 제대로 로드되는지 확인
3. 댓글 작성 테스트

## 참고사항
PR 병합 후 GitHub Pages 배포가 완료되면 실제 사이트에서 기능을 확인할 수 있습니다.