### PR TITLE
Disqus 댓글 레이아웃 문제 수정 (reCAPTCHA 표시 개선)

### DIFF
--- a/blog-state.md
+++ b/blog-state.md
@@ -58,7 +58,12 @@ donbunnypark.github.io/
   "textColor": "#333",
   "footerColor": "#333",
   "blockquoteStyle": "border-left: 4px solid #2e73b8",
-  "responsive": true
+  "responsive": true,
+  "disqusLayout": {
+    "marginLeft": "-2rem",
+    "marginRight": "-2rem",
+    "boxSizing": "border-box"
+  }
 }
 ```
 
@@ -127,6 +132,9 @@ Edges = [
         "url": "[포스트의 전체 웹 주소]",
         "identifier": "[포스트 경로 또는 ID]",
         "title": "[포스트 제목]"
+      },
+      "layoutFixes": {
+        "reCaptchaFix": "음수 마진을 통한 가로 공간 확보"
       }
     }
   }
@@ -138,6 +146,7 @@ Edges = [
 - 마지막 업데이트: 2025-04-19
 - 총 포스트 수: 2
 - 모든 포스트에 Disqus 댓글 기능 추가 (2025-04-19)
+- Disqus 댓글의 reCAPTCHA 레이아웃 문제 해결을 위한 CSS 수정 (2025-04-19)
 
 ## 앞으로 작업 시 참고사항
 - 새 포스트 추가할 때 날짜 형식: "YYYY년 MM월 DD일"

--- a/styles.css
+++ b/styles.css
@@ -168,6 +168,23 @@ footer {
     margin-bottom: 0.5rem;
 }
 
+/* Disqus 댓글 영역 스타일 */
+#disqus_thread {
+    margin-left: -2rem;  /* 부모 요소(.post-content)의 왼쪽 패딩 값만큼 왼쪽 마진을 음수로 설정 */
+    margin-right: -2rem; /* 부모 요소(.post-content)의 오른쪽 패딩 값만큼 오른쪽 마진을 음수로 설정 */
+    box-sizing: border-box; /* 표준 박스 모델 계산 적용 (기본값일 수 있으나 명시) */
+    /* 참고: 이 설정으로 대부분 해결되지만, 만약 필요하다면 min-width: 320px; 와 같은 최소 너비 설정을 추가하여 공간을 더 확보할 수 있습니다. */
+}
+/* 반응형 디자인 고려: 만약 768px 이하 화면에서 .post-content 패딩이 달라진다면, */
+/* 아래 @media 쿼리 안에 해당 너비의 음수 마진을 별도로 설정해야 합니다. */
+/* 현재 스타일시트 기준으로는 .post-content 패딩이 @media에서 변하지 않으므로 아래 코드는 필요 없을 수 있습니다. */
+/* @media (max-width: 768px) { */
+/* #disqus_thread { */
+/* margin-left: -Xrem; /* 모바일에서의 .post-content 패딩 값으로 대체 */ */
+/* margin-right: -Xrem; */
+/* } */
+/* } */
+
 .post-navigation {
     margin-top: 3rem;
     padding-top: 1rem;


### PR DESCRIPTION
## 변경사항
- Disqus 댓글 시스템의 레이아웃 문제 수정 
- reCAPTCHA 인증 시 이미지 그리드가 제대로 표시되지 않는 문제 해결

## 문제 원인
댓글 시스템을 감싸는 `.post-content` 요소의 패딩이 Disqus 댓글 영역(`#disqus_thread`)의 가로 공간을 제한하여 발생하는 레이아웃 문제였습니다.

## 해결 방법
- `#disqus_thread` 요소에 음수 마진(`-2rem`)을 적용하여 부모의 패딩을 상쇄
- 이를 통해 Disqus 영역이 reCAPTCHA 이미지를 표시할 충분한 가로 공간 확보
- 박스 모델 계산 방식 명시(`box-sizing: border-box`)
- CSS 변경이 반응형 디자인에 영향을 주지 않도록 설계

## 구현 내용
1. `styles.css`에 Disqus 댓글 영역을 위한 CSS 규칙 추가
2. `blog-state.md`를 업데이트하여 변경사항 반영

## 테스트 항목
- 포스트 페이지에서 Disqus 댓글 영역의 정상적인 표시 확인
- reCAPTCHA 인증 과정에서 이미지 그리드의 완전한 표시 확인
- 다양한 화면 크기(데스크톱, 태블릿, 모바일)에서의 레이아웃 검증