### PR TITLE
모든 페이지에 Google 애널리틱스 추가

### DIFF
--- a/blog-state.md
+++ b/blog-state.md
@@ -6,7 +6,7 @@
   "name": "Don Bunny Park's Notes",
   "url": "https://moojittokki.github.io/donbunnypark.github.io/",
   "description": "AI와 IT를 배우고 활용하는 일상 블로그",
-  "lastUpdated": "2025-04-19",
+  "lastUpdated": "2025-04-20",
   "createdAt": "2025-04-15",
   "owner": "moojittokki",
   "motto": "AI도 잘 모르고, IT도 서툽니다. 그래도 써보면 뭔가 재미는 있어요. 그런 날것의 기록입니다."
@@ -34,7 +34,8 @@ donbunnypark.github.io/
     "date": "2025-04-15",
     "path": "posts/first-post.html",
     "description": "Don Bunny Park's Notes 블로그를 시작합니다. 앞으로 AI 도구들을 활용하면서 경험한 것들과 배운 것들을 기록할 예정입니다.",
-    "comments": true
+    "comments": true,
+    "analytics": true
   },
   {
     "id": "claude-blogging",
@@ -42,7 +43,8 @@ donbunnypark.github.io/
     "date": "2025-04-15",
     "path": "posts/claude-blogging.html",
     "description": "Claude와 MCP를 활용하여 드디어 GitHub Pages 블로그를 만들게 된 경험과 AI 도구 활용에 대한 생각을 공유합니다.",
-    "comments": true
+    "comments": true,
+    "analytics": true
   }
 ]
 ```
@@ -78,7 +80,8 @@ Nodes = [
   { id: "posts_dir", label: "포스트 디렉토리", type: "directory" },
   { id: "post1", label: "블로그를 시작합니다", type: "post" },
   { id: "post2", label: "Claude를 이용하여 블로그하기", type: "post" },
-  { id: "disqus", label: "Disqus 댓글 시스템", type: "external_service" }
+  { id: "disqus", label: "Disqus 댓글 시스템", type: "external_service" },
+  { id: "google_analytics", label: "Google 애널리틱스", type: "external_service" }
 ]
 
 // 엣지 (관계)
@@ -95,7 +98,11 @@ Edges = [
   { from: "index", to: "post1", relationship: "LINKS_TO" },
   { from: "index", to: "post2", relationship: "LINKS_TO" },
   { from: "post1", to: "disqus", relationship: "INTEGRATES" },
-  { from: "post2", to: "disqus", relationship: "INTEGRATES" }
+  { from: "post2", to: "disqus", relationship: "INTEGRATES" },
+  { from: "blog", to: "google_analytics", relationship: "TRACKS_WITH" },
+  { from: "index", to: "google_analytics", relationship: "TRACKED_BY" },
+  { from: "post1", to: "google_analytics", relationship: "TRACKED_BY" },
+  { from: "post2", to: "google_analytics", relationship: "TRACKED_BY" }
 ]
 ```
 
@@ -136,6 +143,10 @@ Edges = [
       "layoutFixes": {
         "reCaptchaFix": "음수 마진을 통한 가로 공간 확보"
       }
+    },
+    "googleAnalytics": {
+      "trackingID": "G-9MXXQ60B8Y",
+      "implementation": "모든 페이지의 <head> 태그 안에 Google 애널리틱스 스크립트 추가"
     }
   }
 }
@@ -143,17 +154,20 @@ Edges = [
 
 ## 마지막 변경 사항
 - 생성일: 2025-04-15
-- 마지막 업데이트: 2025-04-19
+- 마지막 업데이트: 2025-04-20
 - 총 포스트 수: 2
 - 모든 포스트에 Disqus 댓글 기능 추가 (2025-04-19)
 - Disqus 댓글의 reCAPTCHA 레이아웃 문제 해결을 위한 CSS 수정 (2025-04-19)
+- 모든 페이지에 Google 애널리틱스 추적 코드 추가 (2025-04-20)
 
 ## 앞으로 작업 시 참고사항
 - 새 포스트 추가할 때 날짜 형식: "YYYY년 MM월 DD일"
 - 모든 .html 파일에 스타일시트 링크 포함 필요
 - 폰트 클래스 적용: dongle-light, dongle-regular, dongle-bold
 - 모든 페이지에 헤더와 푸터 일관되게 유지
-- 새 포스트 생성 시 Disqus 댓글 코드도 함께 추가 필요
-  - URL: 'https://moojittokki.github.io/donbunnypark.github.io/[포스트 경로]'
-  - identifier: '[포스트 경로 또는 ID]'
-  - title: '[포스트 제목]'
+- 새 포스트 생성 시 다음 사항 추가 필요:
+  1. Google 애널리틱스 추적 코드 (head 태그 내)
+  2. Disqus 댓글 코드 (컨텐츠 영역 하단)
+     - URL: 'https://moojittokki.github.io/donbunnypark.github.io/[포스트 경로]'
+     - identifier: '[포스트 경로 또는 ID]'
+     - title: '[포스트 제목]'

--- a/index.html
+++ b/index.html
@@ -3,6 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9MXXQ60B8Y"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-9MXXQ60B8Y');
+    </script>
     <title>Don Bunny Park's Notes</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/posts/claude-blogging.html
+++ b/posts/claude-blogging.html
@@ -3,6 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9MXXQ60B8Y"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-9MXXQ60B8Y');
+    </script>
     <title>Claude를 이용하여 블로그하기 - Don Bunny Park's Notes</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/posts/first-post.html
+++ b/posts/first-post.html
@@ -3,6 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9MXXQ60B8Y"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-9MXXQ60B8Y');
+    </script>
     <title>블로그를 시작합니다 - Don Bunny Park's Notes</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## 변경사항
- 모든 페이지에 Google 애널리틱스 추적 코드 추가
  - index.html
  - posts/first-post.html
  - posts/claude-blogging.html
- blog-state.md 파일 업데이트하여 Google 애널리틱스 통합 내용 반영

## 구현 내용
모든 HTML 파일의 `<head>` 섹션에 다음의 Google 애널리틱스 태그를 추가하였습니다:
```html
<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=G-9MXXQ60B8Y"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'G-9MXXQ60B8Y');
</script>
```

## 테스트 항목
- 각 페이지에서 Google 애널리틱스 코드가 정상적으로 로드되는지 확인
- Google 애널리틱스 대시보드에서 사이트 트래픽이 정상적으로 기록되는지 확인